### PR TITLE
feat: Add CI/CD Docker Integration with GitHub Actions

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -1,0 +1,13 @@
+name: Dockerize
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  dockerize:
+    uses: specify/workflows/.github/workflows/dockerize.yml@main
+    with:
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}
+      registry-service: specifyconsortium/specify-asset-service

--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -8,6 +8,8 @@ jobs:
   dockerize:
     uses: specify/workflows/.github/workflows/dockerize.yml@main
     with:
-      username: ${{ secrets.DOCKERHUB_USERNAME }}
-      password: ${{ secrets.DOCKERHUB_TOKEN }}
       registry-service: specifyconsortium/specify-asset-service
+    secrets:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+


### PR DESCRIPTION
This feature brings the "Dockerize" support once only enjoyed by the primary Specify 7 repository to the Web Asset Server. 
Primarily: 
- If desired, we can now version the Web Asset Server with the same scheme of the Specify 7 releases (`vX`, `vX.Y`, `vX.Y.Z`, etc.) 
   - See https://discourse.specifysoftware.org/t/how-to-update-specify-7/2475#p-4782-understanding-docker-release-tags-1
  - That is, if a tag is created following a "release scheme", it will update all corresponding `vX.Y.Z` image tags on Docker Hub. 
- Normal pushes which are not tags and do not match the versioning scheme will push the changes on the branch to a Docker image with a corresponding name

Testing Instructions: 
- [ ] Re-run all jobs for the Dockerize GitHub Workflow
  - [ ] (or optionally) push a branch based on these changes
- [ ]  Inspect the runtime logs of all Actions within the Dockerize GitHub Workflow
- [ ] Once complete, ensure the corresponding branch on [Docker Hub](https://hub.docker.com/r/specifyconsortium/specify-asset-service/tags) has been updated