### PR TITLE
feat: add HEIC/HEIF image format support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL maintainer="Specify Collections Consortium <github.com/specify>"
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
         ghostscript \
         imagemagick \
-        python3.12 \
-        python3.12-venv \
+        libheif-plugin-libde265 \
+        python3.14 \
+        python3.14-venv \
         && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 999 specify && \
@@ -19,7 +20,7 @@ WORKDIR /home/specify
 
 COPY --chown=specify:specify requirements.txt .
 
-RUN python3.12 -m venv ve && ve/bin/pip install --no-cache-dir -r requirements.txt
+RUN python3.14 -m venv ve && ve/bin/pip install --no-cache-dir -r requirements.txt
 
 COPY --chown=specify:specify *.py views ./
 

--- a/server.py
+++ b/server.py
@@ -177,8 +177,8 @@ def resolve_file():
 
     root, ext = path.splitext(storename)
 
-    if mimetype in ('application/pdf', 'image/tiff'):
-        # use PNG for PDF thumbnails
+    if mimetype in ('application/pdf', 'image/tiff', 'image/heic', 'image/heif'):
+        # use PNG for PDF and HEIC thumbnails (ImageMagick can only read HEIC, not write)
         ext = '.png'
 
     scaled_name = "%s_%d%s" % (root, scale, ext)

--- a/settings.py
+++ b/settings.py
@@ -58,7 +58,7 @@ THUMB_DIR = 'thumbnails'
 ORIG_DIR = 'originals'
 
 # Set of mime types that the server will try to thumbnail.
-CAN_THUMBNAIL = {'image/jpeg', 'image/gif', 'image/png', 'image/tiff', 'application/pdf'}
+CAN_THUMBNAIL = {'image/jpeg', 'image/gif', 'image/png', 'image/tiff', 'application/pdf', 'image/heic', 'image/heif'}
 
 # What HTTP server to use for stand-alone operation.
 # SERVER = 'paste' # Requires python-paste package. Fast, and seems to work good.


### PR DESCRIPTION
Fixes #43

This updates the base image to Ubuntu 26.04, Python to 3.14, and add libheif-plugin-libde265 dependency for HEIC/HEIF image processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating thumbnails from HEIC and HEIF images.
  * Expanded thumbnail handling to cover more image/document formats.

* **Bug Fixes**
  * Updated thumbnail processing so PDFs, TIFFs, HEIC, and HEIF files are consistently converted to PNG previews.
  * Improved environment compatibility by using a newer base system and Python version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->